### PR TITLE
restricts plugin access to people with configure access

### DIFF
--- a/admin/src/index.js
+++ b/admin/src/index.js
@@ -3,6 +3,7 @@ import { prefixPluginTranslations } from '@strapi/helper-plugin';
 import { Initializer, PluginIcon } from './components';
 import reducers from './reducers';
 import { getTrad, pluginId, pluginName } from './utils';
+import pluginPermissions from './permissions';
 
 export default {
   register( app ) {
@@ -20,13 +21,7 @@ export default {
 
         return component;
       },
-      permissions: [
-        // Uncomment to set the permissions of the plugin here
-        // {
-        //   action: '', // the action name should be plugin::plugin-name.actionType
-        //   subject: null,
-        // },
-      ],
+      permissions: pluginPermissions.main
     } );
 
     app.registerPlugin( {

--- a/admin/src/pages/App/index.js
+++ b/admin/src/pages/App/index.js
@@ -2,6 +2,8 @@ import React from 'react';
 import { Switch, Route } from 'react-router-dom';
 import { QueryClientProvider, QueryClient } from 'react-query';
 import { Layout } from '@strapi/design-system';
+import { CheckPagePermissions } from '@strapi/helper-plugin';
+import pluginPermissions from '../../permissions';
 
 import { pluginId } from '../../utils';
 import EditView from '../EditView';
@@ -18,17 +20,19 @@ const queryClient = new QueryClient( {
 
 const App = () => {
   return (
-    <QueryClientProvider client={ queryClient }>
-      <Layout>
-        <Switch>
-          <Route path={ `/plugins/${pluginId}` } component={ IndexView } exact />
-          <Route path={ `/plugins/${pluginId}/create` } component={ EditView } exact />
-          <Route path={ `/plugins/${pluginId}/clone/:id` } component={ EditView } exact />
-          <Route path={ `/plugins/${pluginId}/edit/:id` } component={ EditView } exact />
-          <Route path="" component={ NotFound } />
-        </Switch>
-      </Layout>
-    </QueryClientProvider>
+    <CheckPagePermissions permissions={pluginPermissions.main}>
+      <QueryClientProvider client={ queryClient }>
+        <Layout>
+          <Switch>
+            <Route path={ `/plugins/${pluginId}` } component={ IndexView } exact />
+            <Route path={ `/plugins/${pluginId}/create` } component={ EditView } exact />
+            <Route path={ `/plugins/${pluginId}/clone/:id` } component={ EditView } exact />
+            <Route path={ `/plugins/${pluginId}/edit/:id` } component={ EditView } exact />
+            <Route path="" component={ NotFound } />
+          </Switch>
+        </Layout>
+      </QueryClientProvider>
+    </CheckPagePermissions>
   );
 };
 

--- a/admin/src/permissions.js
+++ b/admin/src/permissions.js
@@ -1,0 +1,6 @@
+const pluginPermissions = {
+    main: [
+      { action: 'plugin::content-manager.collection-types.configure-view', subject: null },
+    ]
+  };
+  export default pluginPermissions;


### PR DESCRIPTION
These changes restrict the plugin interface by default to users who are able to configure the view for collection type content. If the user is trusted to change the structure of our content types we assume they should also be able to access the menus. The permissions that are required by the users are set in `permissions.js`. This is a somewhat temporary approach until role based access is added to the plugin.